### PR TITLE
Add support for AltGr character

### DIFF
--- a/TextEditor.cpp
+++ b/TextEditor.cpp
@@ -953,7 +953,7 @@ void TextEditor::HandleKeyboardInputs(bool aParentIsFocused)
 			EnterCharacter('\n', false);
 		else if (!IsReadOnly() && !alt && !ctrl && !super && ImGui::IsKeyPressed(ImGui::GetKeyIndex(ImGuiKey_Tab)))
 			EnterCharacter('\t', shift);
-		if (!IsReadOnly() && !io.InputQueueCharacters.empty() && !ctrl && !super)
+		if (!IsReadOnly() && !io.InputQueueCharacters.empty() && ctrl == alt && !super)
 		{
 			for (int i = 0; i < io.InputQueueCharacters.Size; i++)
 			{


### PR DESCRIPTION
AltGr (or Alt+Ctrl under the hood) is used for some special characters in German/Turkish keyboards. These special characters include but are not limited to '[' ']' '{' '}'.

Without this fix, German/Turkish keyboard owners (like myself) cannot code in programming languages using square or curly braces.