### PR TITLE
Update .gitmodules to use https instead of ssh

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "vendor/regex"]
 	path = vendor/regex
-	url = git@github.com:boostorg/regex.git
+	url = https://github.com/boostorg/regex.git


### PR DESCRIPTION
The use of ssh by default in the .gitmodules file causes errors on the systems which don't have ssh setup with git. However, this is not a problem when you use https by default. 