### PR TITLE
Make Boost regex a private dependency

### DIFF
--- a/ImGuiDebugPanel.cpp
+++ b/ImGuiDebugPanel.cpp
@@ -19,7 +19,7 @@ void TextEditor::ImGuiDebugPanel(const std::string& panelName)
 	{
 		for (int i = 0; i < mLines.size(); i++)
 		{
-			ImGui::Text("%d", mLines[i].size());
+			ImGui::Text("%zu", mLines[i].size());
 		}
 	}
 	if (ImGui::CollapsingHeader("Undo"))

--- a/TextEditor.cpp
+++ b/TextEditor.cpp
@@ -1,6 +1,7 @@
 #include <algorithm>
 #include <string>
 #include <set>
+#include <boost/regex.hpp>
 
 #include "TextEditor.h"
 
@@ -9,10 +10,17 @@
 #define IMGUI_DEFINE_MATH_OPERATORS
 #include "imgui.h" // for imGui::GetCurrentWindow()
 
+
+struct TextEditor::RegexList {
+    std::vector<std::pair<boost::regex, TextEditor::PaletteIndex>> mValue;
+};
+
+
 // --------------------------------------- //
 // ------------- Exposed API ------------- //
 
 TextEditor::TextEditor()
+    : mRegexList(std::make_shared<RegexList>())
 {
 	SetPalette(defaultPalette);
 	mLines.push_back(Line());
@@ -90,9 +98,9 @@ void TextEditor::SetLanguageDefinition(LanguageDefinitionId aValue)
 		break;
 	}
 
-	mRegexList.clear();
+    mRegexList->mValue.clear();
 	for (const auto& r : mLanguageDefinition->mTokenRegexStrings)
-		mRegexList.push_back(std::make_pair(boost::regex(r.first, boost::regex_constants::optimize), r.second));
+        mRegexList->mValue.push_back(std::make_pair(boost::regex(r.first, boost::regex_constants::optimize), r.second));
 
 	Colorize();
 }
@@ -2630,7 +2638,7 @@ void TextEditor::ColorizeRange(int aFromLine, int aToLine)
 				// todo : remove
 				//printf("using regex for %.*s\n", first + 10 < last ? 10 : int(last - first), first);
 
-				for (const auto& p : mRegexList)
+				for (const auto& p : mRegexList->mValue)
 				{
 					bool regexSearchResult = false;
 					try { regexSearchResult = boost::regex_search(first, last, results, p.first, boost::regex_constants::match_continuous); }

--- a/TextEditor.cpp
+++ b/TextEditor.cpp
@@ -2241,7 +2241,7 @@ void TextEditor::Render(bool aParentIsFocused)
 	static char lineNumberBuffer[16];
 	if (mShowLineNumbers)
 	{
-		snprintf(lineNumberBuffer, 16, " %d ", mLines.size());
+		snprintf(lineNumberBuffer, 16, " %zu ", mLines.size());
 		mTextStart += ImGui::GetFont()->CalcTextSizeA(ImGui::GetFontSize(), FLT_MAX, -1.0f, lineNumberBuffer, nullptr, nullptr).x;
 	}
 

--- a/TextEditor.h
+++ b/TextEditor.h
@@ -10,7 +10,6 @@
 #include <unordered_set>
 #include <unordered_map>
 #include <map>
-#include <boost/regex.hpp>
 #include "imgui.h"
 
 class IMGUI_API TextEditor
@@ -304,7 +303,6 @@ private:
 		UndoOperationType mType;
 	};
 
-	typedef std::vector<std::pair<boost::regex, PaletteIndex>> RegexList;
 
 	class UndoRecord
 	{
@@ -456,7 +454,6 @@ private:
 	Palette mPalette;
 	LanguageDefinitionId mLanguageDefinitionId;
 	const LanguageDefinition* mLanguageDefinition = nullptr;
-	RegexList mRegexList;
 
 	inline bool IsHorizontalScrollbarVisible() const { return mCurrentSpaceWidth > mContentWidth; }
 	inline bool IsVerticalScrollbarVisible() const { return mCurrentSpaceHeight > mContentHeight; }
@@ -469,4 +466,8 @@ private:
 	static const std::unordered_map<char, char> OPEN_TO_CLOSE_CHAR;
 	static const std::unordered_map<char, char> CLOSE_TO_OPEN_CHAR;
 	static PaletteId defaultPalette;
+
+private:
+    struct RegexList;
+    std::shared_ptr<RegexList> mRegexList;
 };


### PR DESCRIPTION
Hi,

This PR brings two modifications:

1. use "%zu" in printf specifiers for vector sizes

2. make boost/regex a private dependency 
(i.e. it can be included in TextEditor.cpp, but not in TextEditor.h which is part of the API).

The reason for this is to avoid that users would need to add vendor/boost/regex to their include path (when it is only used by TextEditor.cpp).

- Only TextEditor.cpp will include boost/regex.hpp (private dependency)
- We use a partial pImpl: RegexList is declared inside TextEditor.h, and implemented inside TextEditor.cpp
- We use a shared_ptr<RegexList> instead of unique_ptr , because we want to keep TextEditor copyable (otherwise, this would break the API for existing users)

Cheers,
