### PR TITLE
Input Handling: ignore KeyAlt state on character input handling

### DIFF
--- a/TextEditor.cpp
+++ b/TextEditor.cpp
@@ -2057,7 +2057,7 @@ void TextEditor::HandleKeyboardInputs(bool aParentIsFocused)
 			EnterCharacter('\n', false);
 		else if (!mReadOnly && !alt && !ctrl && !super && ImGui::IsKeyPressed(ImGuiKey_Tab))
 			EnterCharacter('\t', shift);
-		if (!mReadOnly && !io.InputQueueCharacters.empty() && !ctrl && !super)
+		if (!mReadOnly && !io.InputQueueCharacters.empty() && !(ctrl && !alt) && !super) // See https://github.com/santaclose/ImGuiColorTextEdit/pull/34
 		{
 			for (int i = 0; i < io.InputQueueCharacters.Size; i++)
 			{

--- a/TextEditor.cpp
+++ b/TextEditor.cpp
@@ -2057,7 +2057,7 @@ void TextEditor::HandleKeyboardInputs(bool aParentIsFocused)
 			EnterCharacter('\n', false);
 		else if (!mReadOnly && !alt && !ctrl && !super && ImGui::IsKeyPressed(ImGuiKey_Tab))
 			EnterCharacter('\t', shift);
-		if (!mReadOnly && !io.InputQueueCharacters.empty() && ctrl == alt && !super)
+		if (!mReadOnly && !io.InputQueueCharacters.empty() && !ctrl && !super)
 		{
 			for (int i = 0; i < io.InputQueueCharacters.Size; i++)
 			{


### PR DESCRIPTION
 #1 claims, that doing ctrl==alt will enable AltGr behaviour on some keyboard layouts.
As long as this might have been true for some particular cases this wasn't for mine.

As of my testing, when AltGr is pressed, only the io.KeyAlt is set to true and KeyCtrl remains false.
The perfect solution would be to use
`ImGui::IsKeyPressedi(ImGuiKeyAltLeft) && !ctrl`
However I'm not sure about what exactly might be interpreted as AltGr on some keyboard layouts. Since characters input handling itself comes from different part of imgui (so a special charracter will be posted to the queue when the valid ALtGr key was pressed in the first place), I think that skipping `!alt` check in this if statement should work just fine.

Should fix #28, ref https://github.com/AllenDang/cimgui-go/issues/470